### PR TITLE
fix: renomeia os nomes dos diretórios de trabalho

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - php
     ports:
       - "8001:80"
-    working_dir: /var/www/laravel-laravel
+    working_dir: /var/www/laravel
     volumes:
-      - ./:/var/www/laravel-laravel
+      - ./:/var/www/laravel
       - ./docker/nginx/:/etc/nginx/conf.d/
   php:
     container_name: laravel-php
@@ -20,10 +20,10 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8080:8080"
-    working_dir: /var/www/laravel-laravel
+    working_dir: /var/www/laravel
     volumes:
-      - .:/var/www/laravel-laravel
-      - /var/www/laravel-laravel/vendor
+      - .:/var/www/laravel
+      - /var/www/laravel/vendor
   postgres:
     container_name: laravel-postgres
     build:

--- a/docker/nginx/laravel.conf
+++ b/docker/nginx/laravel.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     index index.php;
-    root /var/www/diario-laravel/public;
+    root /var/www/laravel/public;
     client_max_body_size 10000M;
 
     location ~ \.php$ {


### PR DESCRIPTION
Básicamente o problema eram os nomes dos diretórios, recomendo alterar tudo para o nome de `app` ou qualquer coisa generica, assim facilita caso tu queira copiar essa estrutura para outro lugar.